### PR TITLE
Pass down bold color to be same as foreground color

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -16,6 +16,7 @@ const colorTheme: IColorTheme = {
   selectedText: editorStyle.getPropertyValue('--vscode-editor-foreground'),
   cursorText: editorStyle.getPropertyValue('--vscode-terminalCursor-foreground'),
   cursor: editorStyle.getPropertyValue('--vscode-terminalCursor-background'),
+  bold: editorStyle.getPropertyValue('--vscode-editor-foreground'),
   link: editorStyle.getPropertyValue('--vscode-textLink-foreground'),
   statusBarBackground: editorStyle.getPropertyValue('--vscode-statusBar-background'),
   statusBarForeground: editorStyle.getPropertyValue('--vscode-statusBar-foreground'),


### PR DESCRIPTION
I enjoyed using this extension but then realized that [bold font colors do not update on changing color themes](https://github.com/tusaeff/vscode-iterm2-theme-sync/issues/12). This becomes notable when you switch from a dark to light them, and vice versa. Seems like the only thing to update is to pass down the 'bold' color for iTerm to be the same as the foreground since that is also the expected behavior in the native VS Code's terminal.