### PR TITLE
update hook to be not on theme change, but on workspace configuration update

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ async function checkFirstActivation(context: vscode.ExtensionContext) {
 export function activate(context: vscode.ExtensionContext) {
   checkFirstActivation(context);
 
-  vscode.window.onDidChangeActiveColorTheme(async (event) => {
+  vscode.workspace.onDidChangeConfiguration(async (event) => {
     createProfileWithVSCodeTheme(context);
   });
 }


### PR DESCRIPTION
Simple update so that [when you preview a theme, the extension does not trigger the update, which fails](https://github.com/tusaeff/vscode-iterm2-theme-sync/issues/11).